### PR TITLE
incorrectcuror.bash

### DIFF
--- a/incorrectcuror.bash
+++ b/incorrectcuror.bash
@@ -1,0 +1,33 @@
+# .zshrc
+
+# Load vi-mode plugin
+plugins+=(vi-mode)
+
+# Function to set cursor shape in normal mode
+function set_cursor_normal() {
+    echo -ne "\e[2 q" # Change cursor to block shape
+}
+
+# Function to set cursor shape in visual mode
+function set_cursor_visual() {
+    echo -ne "\e[5 q" # Change cursor to vertical bar shape
+}
+
+# Function to switch to normal mode in Zsh's vi-mode
+function switch_to_normal_mode() {
+    zle vi-cmd-mode # Switch to normal mode
+    set_cursor_normal # Set cursor shape to block
+}
+
+# Function to switch to visual mode in Zsh's vi-mode
+function switch_to_visual_mode() {
+    zle vi-char-invisible-mode # Switch to visual mode
+    set_cursor_visual # Set cursor shape to vertical bar
+}
+
+# Bind keys to switch modes and set cursor shapes
+bindkey -v 'h' switch_to_normal_mode
+bindkey -v 'l' switch_to_normal_mode
+bindkey -v 'v' switch_to_visual_mode
+
+# Rest of your Zsh configuration...


### PR DESCRIPTION
Title: **Fix Zsh vi-mode Cursor Shape Bug**

Description:

This commit addresses the bug in the Zsh vi-mode plugin where the cursor shape fails to change back to a block when exiting visual mode. A workaround has been implemented in the `.zshrc` configuration file to manually set the cursor shape in normal and visual modes.

Changes Made:

- Loaded the vi-mode plugin in the `.zshrc` configuration file.
- Added functions to set the cursor shape to block (normal mode) and vertical bar (visual mode).
- Implemented functions to switch between normal and visual modes in Zsh's vi-mode.
- Bound keys 'h', 'l', and 'v' to switch modes and set the appropriate cursor shapes.

This workaround provides a functional solution until the underlying issue in the vi-mode plugin is resolved.

Related Issue: #[Issue Number, if applicable]

[Additional context or information if needed]

Co-authored-by: [Your Name] <[Your Email]>
[Commit Date]

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
